### PR TITLE
properly save privacy settings

### DIFF
--- a/lib/data/datasources/local/privacy_settings_repository.dart
+++ b/lib/data/datasources/local/privacy_settings_repository.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:survey_frontend/data/models/privacy_settings.dart';
+
+abstract class PrivacySettingsRepository{
+  Future<PrivacySettings> read();
+  Future<void> save(PrivacySettings privacySettings);
+}
+
+class PrivacySettingsRepositoryImpl extends PrivacySettingsRepository{
+  final GetStorage _storage;
+
+  PrivacySettingsRepositoryImpl(this._storage);
+  
+  @override
+  Future<PrivacySettings> read() {
+    final json = _storage.read('privacySettings');
+    if(json == null){
+      return Future.value(PrivacySettings(
+        allowLocationTracking: true,
+        allowLocationTrackingFrom: const TimeOfDay(hour: 8, minute: 0),
+        allowLocationTrackingTo: const TimeOfDay(hour: 20, minute: 0)
+      ));
+    }
+    return Future.value(PrivacySettings.fromJson(json));
+  }
+  
+  @override
+  Future<void> save(PrivacySettings privacySettings) async {
+    await _storage.write('privacySettings', privacySettings.toJson());
+  }
+}

--- a/lib/data/models/privacy_settings.dart
+++ b/lib/data/models/privacy_settings.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'privacy_settings.g.dart';
+
+@JsonSerializable()
+class PrivacySettings {
+  final bool allowLocationTracking;
+
+  @JsonKey(fromJson: _timeOfDayFromJson, toJson: _timeOfDayToJson)
+  final TimeOfDay allowLocationTrackingFrom;
+
+  @JsonKey(fromJson: _timeOfDayFromJson, toJson: _timeOfDayToJson)
+  final TimeOfDay allowLocationTrackingTo;
+
+  PrivacySettings({
+    required this.allowLocationTracking,
+    required this.allowLocationTrackingFrom,
+    required this.allowLocationTrackingTo,
+  });
+
+  factory PrivacySettings.fromJson(Map<String, dynamic> json) =>
+      _$PrivacySettingsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PrivacySettingsToJson(this);
+
+  static TimeOfDay _timeOfDayFromJson(String time) {
+    final parts = time.split(":");
+    return TimeOfDay(hour: int.parse(parts[0]), minute: int.parse(parts[1]));
+  }
+
+  static String _timeOfDayToJson(TimeOfDay time) {
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/data/models/privacy_settings.g.dart
+++ b/lib/data/models/privacy_settings.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'privacy_settings.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PrivacySettings _$PrivacySettingsFromJson(Map<String, dynamic> json) =>
+    PrivacySettings(
+      allowLocationTracking: json['allowLocationTracking'] as bool,
+      allowLocationTrackingFrom: PrivacySettings._timeOfDayFromJson(
+          json['allowLocationTrackingFrom'] as String),
+      allowLocationTrackingTo: PrivacySettings._timeOfDayFromJson(
+          json['allowLocationTrackingTo'] as String),
+    );
+
+Map<String, dynamic> _$PrivacySettingsToJson(PrivacySettings instance) =>
+    <String, dynamic>{
+      'allowLocationTracking': instance.allowLocationTracking,
+      'allowLocationTrackingFrom':
+          PrivacySettings._timeOfDayToJson(instance.allowLocationTrackingFrom),
+      'allowLocationTrackingTo':
+          PrivacySettings._timeOfDayToJson(instance.allowLocationTrackingTo),
+    };

--- a/lib/presentation/bindings/initial_bindings.dart
+++ b/lib/presentation/bindings/initial_bindings.dart
@@ -17,6 +17,7 @@ import 'package:survey_frontend/core/usecases/token_provider_impl.dart';
 import 'package:survey_frontend/core/usecases/token_validity_checker_impl.dart';
 import 'package:survey_frontend/data/datasources/initial_survey_service_impl.dart';
 import 'package:survey_frontend/data/datasources/local/database_service.dart';
+import 'package:survey_frontend/data/datasources/local/privacy_settings_repository.dart';
 import 'package:survey_frontend/data/datasources/local/survey_participation_service_impl.dart';
 import 'package:survey_frontend/data/datasources/location_service_impl.dart';
 import 'package:survey_frontend/data/datasources/login_service_impl.dart';
@@ -98,14 +99,17 @@ class InitialBindings extends Bindings {
     Get.put<SurveyResponseService>(SurveyResponseServiceImpl(Get.find(),
         tokenProvider: Get.find<TokenProvider>()));
     Get.put(Connectivity());
-    Get.put<SubmitSurveyUsecase>(
-        SubmitSurveyUsecaseImpl(Get.find(), Get.find(), Get.find(), Get.find()));
+    Get.put<SubmitSurveyUsecase>(SubmitSurveyUsecaseImpl(
+        Get.find(), Get.find(), Get.find(), Get.find()));
     Get.lazyPut<CalendarEventUsecase>(
         () => CalendarEventUsecaseImpl(Get.find()),
         fenix: true);
     Get.lazyPut(() => CalendarController(Get.find()), fenix: true);
     Get.lazyPut<SendLocationDataUsecase>(
         () => SendLocationDataUsecaseImpl(Get.find(), Get.find(), Get.find()),
+        fenix: true);
+    Get.lazyPut<PrivacySettingsRepository>(
+        () => PrivacySettingsRepositoryImpl(Get.find()),
         fenix: true);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+23
+version: 1.0.0+28
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
This pr fixes a bug: when you change the privacy settings, it's not remembered after restarting the application.

The reason of the bug was that GetStorage could not properly save TimeOfDay as json. Now we have our own model ProvacySettings, and fromJson() toJson() methods in it. 

